### PR TITLE
Fix incorrect package import?

### DIFF
--- a/pages/cloudflare/bindings.mdx
+++ b/pages/cloudflare/bindings.mdx
@@ -14,7 +14,7 @@ Install [@opennextjs/cloudflare](https://www.npmjs.com/package/@opennextjs/cloud
 You can access [bindings](https://developers.cloudflare.com/workers/runtime-apis/bindings/) from any route of your Next.js app via `getCloudlfareContext`:
 
 ```js
-import { getCloudflareContext } from "@cloudflare/next-on-pages";
+import { getCloudflareContext } from "@opennextjs/cloudflare";
 
 export async function GET(request) {
 	let responseText = "Hello World";


### PR DESCRIPTION
I believe this should be importing from `@opennextjs/cloudflare`? I'm not 100% sure on this change but it's definitely not correct currently - `@cloudflare/next-on-pages` only exports `getRequestContext`
