### PR TITLE
Small Cloudflare docs improvements

### DIFF
--- a/pages/cloudflare/index.mdx
+++ b/pages/cloudflare/index.mdx
@@ -46,13 +46,13 @@ To help improve compatibility, we encourage you to [report bugs](https://github.
 - [x] [Server-Side Rendering (SSR)](https://nextjs.org/docs/app/building-your-application/rendering/server-components)
 - [x] [Incremental Static Regeneration<sup>1</sup> (ISR)](https://nextjs.org/docs/app/building-your-application/data-fetching/incremental-static-regeneration)
 
-<sup>1</sup> The [Pages Router](https://nextjs.org/docs/pages) is not currently supported as the App Router has been prioritized given the fact that it is the officially recommended one.
- Support for the Pages Router might be added in the future if there is demand for it.
-
-<sup>2</sup> "Manual" revalidation is not supported (i.e. [`revalidateTag()`](https://nextjs.org/docs/app/api-reference/functions/revalidateTag) or [`revalidatePath()`](https://nextjs.org/docs/app/api-reference/functions/revalidatePath))
+<sup>1</sup> "Manual" revalidation is not supported (i.e. [`revalidateTag()`](https://nextjs.org/docs/app/api-reference/functions/revalidateTag) or [`revalidatePath()`](https://nextjs.org/docs/app/api-reference/functions/revalidatePath))
 
 ### Not Yet Supported Next.js features
 
+The following Next.js features are not yet supported — but we welcome both contributions and feedback! Tell us what you'd like to see, or what you'd like to add support for:
+
+- [ ] [Pages Router](https://nextjs.org/docs/pages) (you should use the App Router instead, which was introduced in Next.js 13)
 - [ ] [Partial Prerendering (PPR)](https://nextjs.org/docs/app/building-your-application/rendering/partial-prerendering)
 - [ ] [Middleware](https://nextjs.org/docs/app/building-your-application/routing/middleware)
 - [ ] [Image optimization](https://nextjs.org/docs/app/building-your-application/optimizing/images) (you can integrate Cloudflare Images with Next.js by following [this guide](https://developers.cloudflare.com/images/transform-images/integrate-with-frameworks/))

--- a/pages/cloudflare/index.mdx
+++ b/pages/cloudflare/index.mdx
@@ -40,11 +40,11 @@ To help improve compatibility, we encourage you to [report bugs](https://github.
 ### Supported Next.js features
 
 - [x] [App Router](https://nextjs.org/docs/app)
-- [x] [API routes](https://nextjs.org/docs/pages/building-your-application/routing/api-routes)
-- [x] [Dynamic routes](https://nextjs.org/docs/pages/building-your-application/routing/dynamic-routes)
-- [x] [Static Site Generation (SSG)](https://nextjs.org/docs/pages/building-your-application/rendering/static-site-generation)
-- [x] [Server-Side Rendering (SSR)](https://nextjs.org/docs/pages/building-your-application/rendering/server-side-rendering)
-- [x] [Incremental Static Regeneration<sup>1</sup> (ISR)](https://nextjs.org/docs/pages/building-your-application/data-fetching/incremental-static-regeneration)
+- [x] [Route Handlers](https://nextjs.org/docs/app/building-your-application/routing/route-handlers)
+- [x] [Dynamic routes](https://nextjs.org/docs/app/building-your-application/routing/dynamic-routes)
+- [x] [Static Site Generation (SSG)](https://nextjs.org/docs/app/building-your-application/rendering/server-components#static-rendering-default)
+- [x] [Server-Side Rendering (SSR)](https://nextjs.org/docs/app/building-your-application/rendering/server-components)
+- [x] [Incremental Static Regeneration<sup>1</sup> (ISR)](https://nextjs.org/docs/app/building-your-application/data-fetching/incremental-static-regeneration)
 
 <sup>1</sup> The [Pages Router](https://nextjs.org/docs/pages) is not currently supported as the App Router has been prioritized given the fact that it is the officially recommended one.
  Support for the Pages Router might be added in the future if there is demand for it.
@@ -55,7 +55,7 @@ To help improve compatibility, we encourage you to [report bugs](https://github.
 
 - [ ] [Partial Prerendering (PPR)](https://nextjs.org/docs/app/building-your-application/rendering/partial-prerendering)
 - [ ] [Middleware](https://nextjs.org/docs/app/building-your-application/routing/middleware)
-- [ ] [Image optimization](https://nextjs.org/docs/pages/building-your-application/optimizing/images) (you can integrate Cloudflare Images with Next.js by following [this guide](https://developers.cloudflare.com/images/transform-images/integrate-with-frameworks/))
+- [ ] [Image optimization](https://nextjs.org/docs/app/building-your-application/optimizing/images) (you can integrate Cloudflare Images with Next.js by following [this guide](https://developers.cloudflare.com/images/transform-images/integrate-with-frameworks/))
 - [ ] [Experimental streaming support](https://nextjs.org/blog/next-15-rc#executing-code-after-a-response-with-nextafter-experimental)
 
 ### How @opennextjs/cloudflare Works

--- a/pages/cloudflare/index.mdx
+++ b/pages/cloudflare/index.mdx
@@ -39,14 +39,17 @@ To help improve compatibility, we encourage you to [report bugs](https://github.
 
 ### Supported Next.js features
 
-- [x] [App Router](https://nextjs.org/docs/app) & [Pages Router](https://nextjs.org/docs/pages)
+- [x] [App Router](https://nextjs.org/docs/app)
 - [x] [API routes](https://nextjs.org/docs/pages/building-your-application/routing/api-routes)
 - [x] [Dynamic routes](https://nextjs.org/docs/pages/building-your-application/routing/dynamic-routes)
 - [x] [Static Site Generation (SSG)](https://nextjs.org/docs/pages/building-your-application/rendering/static-site-generation)
 - [x] [Server-Side Rendering (SSR)](https://nextjs.org/docs/pages/building-your-application/rendering/server-side-rendering)
 - [x] [Incremental Static Regeneration<sup>1</sup> (ISR)](https://nextjs.org/docs/pages/building-your-application/data-fetching/incremental-static-regeneration)
 
-<sup>1</sup> "Manual" revalidation is not supported (i.e. [`revalidateTag()`](https://nextjs.org/docs/app/api-reference/functions/revalidateTag) or [`revalidatePath()`](https://nextjs.org/docs/app/api-reference/functions/revalidatePath))
+<sup>1</sup> The [Pages Router](https://nextjs.org/docs/pages) is not currently supported as the App Router has been prioritized given the fact that it is the officially recommended one.
+ Support for the Pages Router might be added in the future if there is demand for it.
+
+<sup>2</sup> "Manual" revalidation is not supported (i.e. [`revalidateTag()`](https://nextjs.org/docs/app/api-reference/functions/revalidateTag) or [`revalidatePath()`](https://nextjs.org/docs/app/api-reference/functions/revalidatePath))
 
 ### Not Yet Supported Next.js features
 


### PR DESCRIPTION
This PR:
 - corrects the fact that the Pages router is actually not supported by the cloudflare adapter
 - fixes various incorrect Next.js links (mainly pointing to the Pages documentation instead of the App one)
