### PR TITLE
Fix outdated experimental attribute

### DIFF
--- a/pages/cloudflare/get-started.mdx
+++ b/pages/cloudflare/get-started.mdx
@@ -40,7 +40,7 @@ main = ".worker-next/index.mjs"
 name = "my-app"
 compatibility_date = "2024-09-23"
 compatibility_flags = ["nodejs_compat"]
-experimental_assets = { directory = ".worker-next/assets", binding = "ASSETS" }
+assets = { directory = ".worker-next/assets", binding = "ASSETS" }
 ```
 
 <Callout>


### PR DESCRIPTION
This is no longer experimental per https://github.com/cloudflare/workers-sdk/releases/tag/wrangler%403.78.9 and we say in docs you must use 3.78.10 or later

Resolves https://github.com/opennextjs/opennextjs-cloudflare/issues/58