### PR TITLE
Update ordering of Cloudflare pages

### DIFF
--- a/pages/cloudflare/_meta.json
+++ b/pages/cloudflare/_meta.json
@@ -1,3 +1,8 @@
 {
-  "index": "Overview"
+  "index": "Overview",
+  "get-started": "",
+  "bindings": "",
+  "caching": "",
+  "examples": "",
+  "troubleshooting": ""
 }


### PR DESCRIPTION
Updates the order of the Cloudflare pages

| Before (alphabetically ordered) | After (custom order) |
|--------|--------|
| ![Screenshot 2024-11-08 at 13 24 08](https://github.com/user-attachments/assets/17182918-ce02-4c71-8a7c-da4d69588143) | ![Screenshot 2024-11-08 at 13 23 49](https://github.com/user-attachments/assets/a26ffba6-bfff-4408-ae8a-1c1e3f8e5b82) |

Mainly my issue is that the `Get Started` page is currently lower than bindings, etc... that doesn't really make much sense to me 😕 

Note: in the _meta.json we could just specify the `get-started` entry, but I did include all of the pages there since I think that it makes more sense to explicitly define what order we want all the pages to be in