### PR TITLE
docs: experimental template callout msg removed

### DIFF
--- a/pages/cloudflare/get-started.mdx
+++ b/pages/cloudflare/get-started.mdx
@@ -11,11 +11,6 @@ To create a new Next.js app, pre-configured to run on Cloudflare using @opennext
 npm create cloudflare@latest -- --template https://github.com/flarelabs-net/workers-next
 ```
 
-<Callout>
-The experimental template for the Next framework is still based on 0.2.
-Use the template from `flarelabs-net/workers-next` as indicated above to use 0.3.
-</Callout>
-
 #### Existing Next.js apps
 
 ##### 1. Install @opennextjs/cloudflare


### PR DESCRIPTION
The experimental template has been updated to version 0.3. As it has been brought up to the latest version, this callout message is no longer necessary.