### PR TITLE
remove all references to `wrangler.toml`

### DIFF
--- a/pages/cloudflare/bindings.mdx
+++ b/pages/cloudflare/bindings.mdx
@@ -7,7 +7,7 @@ import { Callout } from 'nextra/components';
 
 #### How to configure your Next.js app so it can access bindings
 
-Install [@opennextjs/cloudflare](https://www.npmjs.com/package/@opennextjs/cloudflare), and then add a `wrangler.toml` file in the root directory of your Next.js app, as described in [Get Started](/cloudflare/get-started).
+Install [@opennextjs/cloudflare](https://www.npmjs.com/package/@opennextjs/cloudflare), and then add a [wrangler configuration file](https://developers.cloudflare.com/workers/wrangler/configuration/) in the root directory of your Next.js app, as described in [Get Started](/cloudflare/get-started#3-create-a-wranglerjson-file).
 
 #### How to access bindings in your Next.js app
 
@@ -29,7 +29,7 @@ export async function GET(request) {
 
 #### How to add bindings to your Worker
 
-Add bindings to your Worker by [adding them to your `wrangler.toml` configuration file](https://developers.cloudflare.com/workers/wrangler/configuration/).
+Add bindings to your Worker by adding them to your [wrangler configuration file](https://developers.cloudflare.com/workers/wrangler/configuration/).
 
 ## TypeScript type declarations for bindings
 

--- a/pages/cloudflare/get-started.mdx
+++ b/pages/cloudflare/get-started.mdx
@@ -33,16 +33,16 @@ npm install --save-dev wrangler@latest
 You must use Wrangler version `3.99.0` or later to deploy Next.js apps using `@opennextjs/cloudflare`.
 </Callout>
 
-##### 3. Create a `wrangler.json` file
+##### 3. Create a wrangler configuration file
 
 <Callout type='info'>
 This step is optional since `@opennextjs/cloudflare` creates this file for you during the build process (if not already present).
 </Callout>
 
-A [`wrangler.json`](https://developers.cloudflare.com/workers/wrangler/configuration/) file is needed for your
+A [wrangler configuration file](https://developers.cloudflare.com/workers/wrangler/configuration/) is needed for your
 application to be previewed and deployed, it is also where you configure your Worker and define what resources it can access via [bindings](https://developers.cloudflare.com/workers/runtime-apis/bindings/service-bindings).
 
-You can create one yourself with the following content:
+You can create one yourself in the root directory of your Next.js app with the name `wrangler.json` and the following content:
 ```jsonc
 {
   "main": ".open-next/worker.js",

--- a/pages/cloudflare/troubleshooting.mdx
+++ b/pages/cloudflare/troubleshooting.mdx
@@ -17,7 +17,8 @@ The Cloudflare Account you are deploying to is on the Workers Free plan, which [
 
 ### My app fails to build when I import a specific NPM package
 
-First, make sure that the `nodejs_compat` compatibility flag is enabled, and your compatibility date is set to on or after "2024-09-23", in your `wrangler.toml` file. [Refer to the Workers docs](https://developers.cloudflare.com/workers/runtime-apis/nodejs/) for more details on Node.js support in Cloudflare Workers.
+First, make sure that the `nodejs_compat` compatibility flag is enabled, and your compatibility date is set to on or after "2024-09-23", in your [wrangler configuration file](https://developers.cloudflare.com/workers/wrangler/configuration/).
+Refer to the [Node.js Workers docs](https://developers.cloudflare.com/workers/runtime-apis/nodejs/) for more details on Node.js support in Cloudflare Workers.
 
 Some NPM packages define multiple exports. For example:
 


### PR DESCRIPTION
Since we're moving to promoting the json format (https://github.com/cloudflare/workers-sdk/pull/7676) instead of toml for the wrangler config I went back to the Cloudflare docs here to remove all references to `wrangler.toml`

> [!Note]
> I didn't remove those from the `0.2` section as I think it should be kept there.
>
> Although I would actually prefer to get rid of the `0.2` section altogether, especially since we had this section+migration for a while (devs that were on 0.2 would most likely have already migrated) and the package itself is still in beta/experimental anyways.
> @vicb any plan/idea if/when we can remove the `0.2` docs?

> [!Note]
> As you can see in this PR my preference when referring to the config file is to generically call it something like `wrangler configuration file` instead of directly `wrangler.json` I think that that's just more accurate and future proof (if for example we later decide to default to `wrangler.jsonc` for example, or even to a `wrangler.config.ts`, all the generic references to the file would still be correct and wouldn't need to be updated)