### PR TITLE
add warnings in the aws and cloudflare docs regarding the limited windows support

### DIFF
--- a/pages/aws/index.mdx
+++ b/pages/aws/index.mdx
@@ -1,5 +1,6 @@
 import { SITE } from '../../config';
 import { Callout } from 'nextra/components';
+import WindowsSupport from '../../shared/WindowsSupport.mdx';
 
 <Callout>
 This docs is for the V3 of OpenNext. If you are looking for the V2 docs, you can find them [here](/aws/v2).
@@ -45,16 +46,7 @@ OpenNext aims to support all Next.js 14 features. Some features are work in prog
 ---
 
 <Callout type='info'>
-
-OpenNext can be used on Windows systems but Windows full support is not guaranteed because:
- - historically the Next.js tooling itself has had Windows support issues
-   (and OpenNext is built on these tools)
- - the OpenNext team has limited capacity and fully supporting Windows (given the point above)
-   has been determined to be a lower priority, thus the effort and testing on Windows is limited
-
-Given the above, you can develop your application under Windows at your own risk. If you don't have an alternative we
-recommend running OpenNext using [WSL2](https://learn.microsoft.com/en-us/windows/wsl/) or in a Linux Virtual Machine.
-
+    <WindowsSupport />
 </Callout>
 
 ---

--- a/pages/aws/index.mdx
+++ b/pages/aws/index.mdx
@@ -44,4 +44,19 @@ OpenNext aims to support all Next.js 14 features. Some features are work in prog
 
 ---
 
+<Callout type='info'>
+
+OpenNext can be used on Windows systems but Windows full support is not guaranteed because:
+ - historically the Next.js tooling itself has had Windows support issues
+   (and OpenNext is built on these tools)
+ - the OpenNext team has limited capacity and fully supporting Windows (given the point above)
+   has been determined to be a lower priority, thus the effort and testing on Windows is limited
+
+Given the above, you can develop your application under Windows at your own risk. If you don't have an alternative we
+recommend running OpenNext using [WSL2](https://learn.microsoft.com/en-us/windows/wsl/) or in a Linux Virtual Machine.
+
+</Callout>
+
+---
+
 [Get started](/aws/get_started) with deploying your app with OpenNext and your favorite framework.

--- a/pages/cloudflare/index.mdx
+++ b/pages/cloudflare/index.mdx
@@ -57,6 +57,17 @@ We will update the list as we progress towards releasing 1.0.
 
 We welcome both contributions and feedback!
 
+### Windows support
+
+The OpenNext Cloudflare can be used on Windows systems but Windows full support is not guaranteed because:
+ - historically the Next.js tooling itself has had Windows support issues
+   (and OpenNext is built on these tools)
+ - the OpenNext team has limited capacity and fully supporting Windows (given the point above)
+   has been determined to be a lower priority, thus the effort and testing on Windows is limited
+
+Given the above, you can develop your application under Windows at your own risk. If you don't have an alternative we
+recommend running OpenNext using [WSL2](https://learn.microsoft.com/en-us/windows/wsl/) or in a Linux Virtual Machine.
+
 ### How @opennextjs/cloudflare Works
 
 The OpenNext Cloudflare adapter works by taking the Next.js build output and transforming it, so that it can run in Cloudflare Workers.

--- a/pages/cloudflare/index.mdx
+++ b/pages/cloudflare/index.mdx
@@ -1,5 +1,6 @@
 import { SITE } from '../../config';
 import { Callout } from 'nextra/components';
+import WindowsSupport from '../../shared/WindowsSupport.mdx';
 
 ## Cloudflare
 
@@ -59,14 +60,7 @@ We welcome both contributions and feedback!
 
 ### Windows support
 
-The OpenNext Cloudflare can be used on Windows systems but Windows full support is not guaranteed because:
- - historically the Next.js tooling itself has had Windows support issues
-   (and OpenNext is built on these tools)
- - the OpenNext team has limited capacity and fully supporting Windows (given the point above)
-   has been determined to be a lower priority, thus the effort and testing on Windows is limited
-
-Given the above, you can develop your application under Windows at your own risk. If you don't have an alternative we
-recommend running OpenNext using [WSL2](https://learn.microsoft.com/en-us/windows/wsl/) or in a Linux Virtual Machine.
+<WindowsSupport />
 
 ### How @opennextjs/cloudflare Works
 

--- a/shared/WindowsSupport.mdx
+++ b/shared/WindowsSupport.mdx
@@ -1,0 +1,12 @@
+OpenNext can be used on Windows systems but Windows full support is not guaranteed because:
+ - historically the Next.js tooling itself has had Windows support issues
+   (and OpenNext is built on these tools)
+ - the OpenNext team has limited capacity and fully supporting Windows (given the point above)
+   has been determined to be a lower priority, thus the effort and testing on Windows is limited
+
+Given the above, you can develop your application under Windows at your own risk. If you don't have an alternative we
+recommend either:
+ - running OpenNext using [WSL2](https://learn.microsoft.com/en-us/windows/wsl/),
+ - in a Linux Virtual Machine or
+ - develop your application using the standard Next.js tooling and deploy it using OpenNext in CI/CD systems such
+   as [GitHub Actions](https://github.com/features/actions) that run linux/MacOS environments


### PR DESCRIPTION
As per https://github.com/opennextjs/opennextjs-cloudflare/issues/236#issuecomment-2585918127

> [!Note]
> Maybe the warning could go in the [OpenNext overview page](https://github.com/opennextjs/docs/blob/main/pages/index.mdx) itself?
>
> I considered that but I am not sure if we should put such a warning front and center (as one of the first things devs would see).
> Maybe it's better to just duplicate the warning for now and then reconsolidate it when/if we decide to restructure the docs to better document the shared aspects of the adapters?