### PR TITLE
remove doc comment in Cloudflare get started telling people to use the app router instead of the pages one

### DIFF
--- a/pages/cloudflare/index.mdx
+++ b/pages/cloudflare/index.mdx
@@ -51,7 +51,7 @@ We will update the list as we progress towards releasing 1.0.
 - [x] [Server-Side Rendering (SSR)](https://nextjs.org/docs/app/building-your-application/rendering/server-components)
 - [x] [Middleware](https://nextjs.org/docs/app/building-your-application/routing/middleware)
 - [x] [Image optimization](https://nextjs.org/docs/app/building-your-application/optimizing/images) (you can integrate Cloudflare Images with Next.js by following [this guide](https://developers.cloudflare.com/images/transform-images/integrate-with-frameworks/))
-- [ ] [Pages Router](https://nextjs.org/docs/pages) (you should use the App Router instead, which was introduced in Next.js 13)
+- [ ] [Pages Router](https://nextjs.org/docs/pages)
 - [ ] [Incremental Static Regeneration (ISR)](https://nextjs.org/docs/app/building-your-application/data-fetching/incremental-static-regeneration)
 - [ ] [Partial Prerendering (PPR)](https://nextjs.org/docs/app/building-your-application/rendering/partial-prerendering)
 - [ ] [Support for after](https://nextjs.org/blog/next-15-rc#executing-code-after-a-response-with-nextafter-experimental)


### PR DESCRIPTION
Since we're planning to eventually support the pages router let's remove the comment saying not to use it as it might give the impression that we don't want to ever support it