### PR TITLE
Fix reference to OpenNextConfig type in streaming example

### DIFF
--- a/pages/aws/config/simple_example.mdx
+++ b/pages/aws/config/simple_example.mdx
@@ -22,7 +22,7 @@ Here you can find the most common `open-next.config.ts` file examples that you c
 </Callout>
 
 ```ts
-import type { OpenNextConfig } from '@opennextjs/aws/types/open-next.ts';
+import type { OpenNextConfig } from '@opennextjs/aws/types/open-next.js';
 const config = {
   default: {
     override: {


### PR DESCRIPTION
Changes the import from `@opennextjs/aws/types/open-next.ts` to `@opennextjs/aws/types/open-next.js` for `OpenNextConfig` to bring it in line with the other examples on the page.