### PR TITLE
[cloudflare] add more information around what `NEXT_CACHE_REVALIDATION_WORKER` is

### DIFF
--- a/pages/cloudflare/caching.mdx
+++ b/pages/cloudflare/caching.mdx
@@ -32,7 +32,7 @@ npx wrangler@latest kv namespace create <YOUR_NAMESPACE_NAME>
 
 ##### 2. Add the KV namespace and Service Binding to your Worker
 
-The binding name used in your app's worker is `NEXT_CACHE_WORKERS_KV`.
+The binding name used in your app's worker is `NEXT_CACHE_WORKERS_KV`. The service binding should be a self reference to your worker where `<WORKER_NAME>` is the name in your wrangler configuration file.
 
 ```jsonc
 // wrangler.jsonc
@@ -93,7 +93,7 @@ To use on-demand revalidation, you should also follow the [ISR setup steps](#inc
 
 ##### 1. Create a D1 database and Service Binding
 
-The binding name used in your app's worker is `NEXT_CACHE_D1`.
+The binding name used in your app's worker is `NEXT_CACHE_D1`. The service binding should be a self reference to your worker where `<WORKER_NAME>` is the name in your wrangler configuration file.
 
 ```jsonc
 // wrangler.jsonc


### PR DESCRIPTION
This change adds more context around what `NEXT_CACHE_REVALIDATION_WORKER` is. This confused me originally when I was going through the docs to set up caching. Still not 100% sure if this is accurate, but I noticed in all of the e2e examples this binding was a self reference (and I don't see anywhere in the docs or in another project on Github describing creating this worker). Mostly just wanted to open this for discussion because I'm not sure where the best place is and thought I might be able to improve the docs for the next person who sees this.