### PR TITLE
[cloudflare] Remove pre 1.0 callout

### DIFF
--- a/pages/cloudflare/index.mdx
+++ b/pages/cloudflare/index.mdx
@@ -6,13 +6,6 @@ import WindowsSupport from "../../shared/WindowsSupport.mdx";
 
 The [`@opennextjs/cloudflare`](https://www.npmjs.com/package/@opennextjs/cloudflare) adapter lets you deploy Next.js apps to [Cloudflare Workers](https://developers.cloudflare.com/workers) using the [Node.js "runtime" from Next.js](https://nextjs.org/docs/app/building-your-application/rendering/edge-and-nodejs-runtimes).
 
-<Callout>
-[`@opennextjs/cloudflare`](https://www.npmjs.com/package/@opennextjs/cloudflare) is pre 1.0, and still in active development. You should try it, [report bugs](https://github.com/opennextjs/opennextjs-cloudflare/issues), [share feedback](https://github.com/opennextjs/opennextjs-cloudflare/discussions), and contribute code to help make running Next.js apps on Cloudflare easier. We don't quite yet recommend using it for mission-critical production apps.
-
-You can also use [`@cloudflare/next-on-pages`](https://www.npmjs.com/package/@cloudflare/next-on-pages) to deploy Next.js apps to Cloudflare Pages. You can review the differences in supported Next.js features below and by reviewing [the docs for `@cloudflare/next-on-pages`](https://developers.cloudflare.com/pages/framework-guides/nextjs/ssr/supported-features/), and understand the differences between Workers and Pages [here](https://developers.cloudflare.com/workers/static-assets/compatibility-matrix/).
-
-</Callout>
-
 ### Get Started
 
 ##### New apps


### PR DESCRIPTION
This is confusing (example: https://github.com/cloudflare/next-on-pages/issues/954#issuecomment-2749804240) given that `@opennextjs/cloudflare` has been the best way to deploy Next.js apps to Cloudflare for some time now.