### PR TITLE
docs(cloudflare): fix the environment variable howto

### DIFF
--- a/pages/cloudflare/howtos/env-vars.mdx
+++ b/pages/cloudflare/howtos/env-vars.mdx
@@ -23,13 +23,14 @@ The "production" environment is used by default when `NEXTJS_ENV` is not explici
 
 ### Production
 
-`.env` and `.dev.vars` are local files that should not be added to source control. You should instead use the cloudflare dashboard to set your environment variables for production.
+`.env` and `.dev.vars` are local files that should not be added to source control. You should instead use the Cloudflare dashboard to set your environment variables for production.
 
-Next.js has [2 kinds](https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables#bundling-environment-variables-for-the-browser) of environment variables:
+#### Workers Builds
 
-- non-`NEXT_PUBLIC_` variables which are only available on the server
-- `NEXT_PUBLIC_` variables on the other hand are available to the browser
+When you use [Workers Builds](https://developers.cloudflare.com/workers/ci-cd/builds/) to deploy your application, the environment variables must be set in the ["Build variables and secrets"](https://developers.cloudflare.com/workers/ci-cd/builds/configuration/).
 
-Those are called runtime environment variables (non-`NEXT_PUBLIC_`) and buildtime environment variables (`NEXT_PUBLIC_`) on the Cloudflare paltform.
+By settings the "Build variables and secrets", the Next build executed by Workers Builds will have access to the environment variables. It needs that access to inline the [`NEXT_PUBLIC_...` variables](https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables#bundling-environment-variables-for-the-browser) and access non-`NEXT_PUBLIC_...` variables needed for SSG pages.
 
-You can set the runtime environment variables (non-`NEXT_PUBLIC_`) by following those [instructions](https://developers.cloudflare.com/workers/configuration/environment-variables/#add-environment-variables-via-the-dashboard). The build time environment variables (`NEXT_PUBLIC_`) should be set in the [Builds Configuration](https://developers.cloudflare.com/workers/ci-cd/builds/configuration/) so that their value can be inlined by the Workers Builds.
+#### Runtime variables
+
+Your Next application needs to access environment variables at runtime. You should always set the runtime environment variables [in the Cloudflare dashboard](https://developers.cloudflare.com/workers/configuration/environment-variables/#add-environment-variables-via-the-dashboard)


### PR DESCRIPTION
We previously told users to:
- add `NEXT_PUBLIC_...` vars to the build vars
- add non-`NEXT_PUBLIC_...` vars to the runtime vars

But:
- non-`NEXT_PUBLIC_...` vars can be accessed at build time (i.e. for SSG) so they also need to be populated in the build vars
- `NEXT_PUBLIC_...` vars are also added to the runtime vars on Vercel, so they also need to be populated in the runtime vars