### PR TITLE
[cloudflare] added clarification on workers size limit

### DIFF
--- a/pages/cloudflare/index.mdx
+++ b/pages/cloudflare/index.mdx
@@ -64,3 +64,13 @@ The OpenNext Cloudflare adapter works by taking the Next.js build output and tra
 When you add [@opennextjs/cloudflare](https://www.npmjs.com/package/@opennextjs/cloudflare) as a dependency to your Next.js app, and then run `npx opennextjs-cloudflare` the adapter first builds your app by running the `build` script in your `package.json`, and then transforms the build output to a format that you can run locally using [Wrangler](https://developers.cloudflare.com/workers/wrangler/), and deploy to Cloudflare.
 
 You can view the code for `@opennextjs/cloudflare` [here](https://github.com/opennextjs/opennextjs-cloudflare/blob/main/packages/cloudflare/src) to understand what it does under the hood.
+
+### Note on Worker Size Limits
+
+The size limit of a Cloudflare Worker is 3 MiB on the Workers Free plan, and 10 MiB on the Workers Paid plan. After building your Worker, `wrangler` will show both the original and compressed sizes:
+
+```
+Total Upload: 13833.20 KiB / gzip: 2295.89 KiB
+```
+
+Only the latter (compressed size) matters for [the Worker size limit](https://developers.cloudflare.com/workers/platform/limits/#worker-size).

--- a/pages/cloudflare/troubleshooting.mdx
+++ b/pages/cloudflare/troubleshooting.mdx
@@ -14,6 +14,8 @@ If you need to deploy to Cloudflare Pages, you can use `@cloudflare/next-on-page
 
 The Cloudflare Account you are deploying to is on the Workers Free plan, which [limits the size of each Worker to 3 MiB](https://developers.cloudflare.com/workers/platform/limits/#worker-size). When you subscribe to the Workers Paid plan, each Worker can be up to 10 MiB.
 
+When deploying your Worker, `wrangler` will show both the original and compressed sizes. Only the latter (gzipped size) matters for these limits.
+
 ### My app fails to build when I import a specific NPM package
 
 First, make sure that the `nodejs_compat` compatibility flag is enabled, and your compatibility date is set to on or after "2024-09-23", in your [wrangler configuration file](https://developers.cloudflare.com/workers/wrangler/configuration/).


### PR DESCRIPTION
This proposal adds a more detailed clarification on the Workers size limits. The part on the "Overview" is optional, although I personally think that's an important detail to have in mind. Alternatively we could merge the two into the "Troubleshooting" section.