### PR TITLE
[cloudflare] Update examples.mdx

### DIFF
--- a/pages/cloudflare/examples.mdx
+++ b/pages/cloudflare/examples.mdx
@@ -15,7 +15,6 @@ Basic example apps are included in the repository for `@opennextjs/cloudflare` p
 - [_`create-next-app`_](https://github.com/opennextjs/opennextjs-cloudflare/tree/main/examples/create-next-app) — a Next.js project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
 - [_`middleware`_](https://github.com/opennextjs/opennextjs-cloudflare/tree/main/examples/middleware) — a minimal Next.js project using middleware
 - [_`vercel-blog-starter`_](https://github.com/opennextjs/opennextjs-cloudflare/tree/main/examples/vercel-blog-starter) — a blog project using SSG
-- [_`vercel-commerce`_](https://github.com/opennextjs/opennextjs-cloudflare/tree/main/examples/vercel-commerce) - an ecommerce application
 
 You can use these to understand how to configure your Next.js app to use `@opennextjs/cloudflare`, or refer to [Get Started](/cloudflare/get-started).
 

--- a/pages/cloudflare/examples.mdx
+++ b/pages/cloudflare/examples.mdx
@@ -13,9 +13,9 @@ npm create cloudflare@latest -- my-next-app --framework=next --platform=workers
 Basic example apps are included in the repository for `@opennextjs/cloudflare` package:
 
 - [_`create-next-app`_](https://github.com/opennextjs/opennextjs-cloudflare/tree/main/examples/create-next-app) — a Next.js project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
-- [_`api`_](https://github.com/opennextjs/opennextjs-cloudflare/tree/main/examples/api) — a minimal Next.js project with a single API route
 - [_`middleware`_](https://github.com/opennextjs/opennextjs-cloudflare/tree/main/examples/middleware) — a minimal Next.js project using middleware
 - [_`vercel-blog-starter`_](https://github.com/opennextjs/opennextjs-cloudflare/tree/main/examples/vercel-blog-starter) — a blog project using SSG
+- [_`vercel-commerce`_](https://github.com/opennextjs/opennextjs-cloudflare/tree/main/examples/vercel-commerce) - an ecommerce application
 
 You can use these to understand how to configure your Next.js app to use `@opennextjs/cloudflare`, or refer to [Get Started](/cloudflare/get-started).
 


### PR DESCRIPTION
This pull request addresses the removal of the deprecated `api` link from the examples documentation and integrates the `vercel-commerce` link for enhanced user guidance.

Specifically:

* Removed the outdated `api` link from `examples.mdx`.
* Added a link to `vercel-commerce` to provide users with an updated and relevant resource for commerce examples.

This change ensures the documentation remains accurate and directs users to the most current and helpful resources.