### PR TITLE
doc(cloudflare): update type generation command

### DIFF
--- a/pages/cloudflare/bindings.mdx
+++ b/pages/cloudflare/bindings.mdx
@@ -46,7 +46,7 @@ Add bindings to your Worker by adding them to your [wrangler configuration file]
 To ensure that the `env` object from `getCloudflareContext().env` above has accurate TypeScript types, run the following Wrangler command to [generate types that match your Worker's configuration](https://developers.cloudflare.com/workers/languages/typescript/#generate-types-that-match-your-workers-configuration-experimental):
 
 ```
-npx wrangler types --experimental-include-runtime
+npx wrangler types --env-interface CloudflareEnv
 ```
 
 This will generate a `d.ts` file and (by default) save it to `.wrangler/types/runtime.d.ts`. You will be prompted in the command's output to add that file to your `tsconfig.json`'s `compilerOptions.types` array.
@@ -54,10 +54,10 @@ This will generate a `d.ts` file and (by default) save it to `.wrangler/types/ru
 If you would like to commit the file to git, you can provide a custom path. Here, for instance, the `runtime.d.ts` file will be saved to the root of your project:
 
 ```bash
-npx wrangler types --experimental-include-runtime="./runtime.d.ts"
+npx wrangler types --env-interface CloudflareEnv ./runtime.d.ts
 ```
 
-To ensure that your types are always up-to-date, make sure to run `wrangler types --experimental-include-runtime` after any changes to your config file.
+To ensure that your types are always up-to-date, make sure to run `wrangler types --env-interface CloudflareEnv` after any changes to your config file.
 
 ## Other Cloudflare APIs (`cf`, `ctx`)
 


### PR DESCRIPTION
This PR updates following:

1. We are not using `--experimental-include-runtime` anymore, since Wrangler now generates runtime types too. When running `wrangler types` with the flag above, CLI shows an error and stops generating types;
```
✘ [ERROR] You no longer need to use --experimental-include-runtime.

  `wrangler types` will now generate runtime types in the same file as the Env types.
  You should delete the old runtime types file, and remove it from your tsconfig.json.
  Then rerun `wrangler types`.
```

2. Include `--env-interface` flag. This ensures that `getCloudflareContext()` returns correct binding types. OpenNext has `CloudflareEnv` interface but by default Wrangler saves bindings in `Env` interface. This causes `CloudflareEnv` (used by OpenNext) not have the correct types for bindings.

Some issues I've found about this:
- https://github.com/opennextjs/opennextjs-cloudflare/issues/597
- https://github.com/opennextjs/opennextjs-cloudflare/issues/238