### PR TITLE
Update docs about sentry server sourcemaps

### DIFF
--- a/pages/aws/common_issues.mdx
+++ b/pages/aws/common_issues.mdx
@@ -17,14 +17,28 @@ You might stumble upon this error inside cloudwatch logs: `Cannot find module 'n
 Next might incorrectly include some dependencies in the bundle. To remove them you can use this configuration inside `next.config.js`:
 
 ```javascript
-experimental: {
-    outputFileTracingExcludes: {
-      "*": ["node_modules/the-unwanted-package"],
-    },
-  },
+outputFileTracingExcludes: {
+  "*": ["node_modules/the-unwanted-package"],
+},
 ```
 
 Also you should not add sharp as a dependencies unless absolutely necessary, the image optimization already has it's own version of sharp.
+
+##### Sentry server sourcemaps
+
+Sentry does not remove server side sourcemaps, only client ones, even if "deleteSourcemapsAfterUpload" is true. [See the Sentry source code](https://github.com/getsentry/sentry-javascript/blob/develop/packages/nextjs/src/config/webpackPluginOptions.ts#L83).
+
+Excluding them from standalone output reduces bundle size:
+
+```javascript
+outputFileTracingExcludes: {
+  "*": [
+    './**/*.js.map',
+    './**/*.mjs.map',
+    './**/*.cjs.map'
+  ],
+},
+```
 
 #### Patch fetch behaviour for ISR. Only for next@13.5.1+
 

--- a/pages/aws/common_issues.mdx
+++ b/pages/aws/common_issues.mdx
@@ -25,6 +25,7 @@ outputFileTracingExcludes: { // or experimental.outputFileTracingExcludes on Nex
 Also you should not add sharp as a dependencies unless absolutely necessary, the image optimization already has it's own version of sharp.
 
 ##### Remove sourcemaps
+
 Source maps could add a lot to the bundle, excluding them from standalone output could be worth it.
 For example, Sentry does not remove server side sourcemaps, only client ones, even if "deleteSourcemapsAfterUpload" is true. [See the Sentry source code](https://github.com/getsentry/sentry-javascript/blob/develop/packages/nextjs/src/config/webpackPluginOptions.ts#L83).
 

--- a/pages/aws/common_issues.mdx
+++ b/pages/aws/common_issues.mdx
@@ -17,18 +17,18 @@ You might stumble upon this error inside cloudwatch logs: `Cannot find module 'n
 Next might incorrectly include some dependencies in the bundle. To remove them you can use this configuration inside `next.config.js`:
 
 ```javascript
-outputFileTracingExcludes: {
+outputFileTracingExcludes: { // or experimental.outputFileTracingExcludes on Next < 15
   "*": ["node_modules/the-unwanted-package"],
 },
 ```
 
 Also you should not add sharp as a dependencies unless absolutely necessary, the image optimization already has it's own version of sharp.
 
-##### Sentry server sourcemaps
+##### Remove sourcemaps
+Source maps could add a lot to the bundle, excluding them from standalone output could be worth it.
+For example, Sentry does not remove server side sourcemaps, only client ones, even if "deleteSourcemapsAfterUpload" is true. [See the Sentry source code](https://github.com/getsentry/sentry-javascript/blob/develop/packages/nextjs/src/config/webpackPluginOptions.ts#L83).
 
-Sentry does not remove server side sourcemaps, only client ones, even if "deleteSourcemapsAfterUpload" is true. [See the Sentry source code](https://github.com/getsentry/sentry-javascript/blob/develop/packages/nextjs/src/config/webpackPluginOptions.ts#L83).
-
-Excluding them from standalone output reduces bundle size:
+You could exclude sourcemaps similarly:
 
 ```javascript
 outputFileTracingExcludes: {


### PR DESCRIPTION
* Removed experimental from outputFileTracingExcludes, next has it in root config
* Added info about Sentry serverside sourcemaps