### PR TITLE
docs(cloudflare): react-textarea-autosize uses a workerd build conditions

### DIFF
--- a/pages/cloudflare/howtos/workerd.mdx
+++ b/pages/cloudflare/howtos/workerd.mdx
@@ -44,5 +44,6 @@ export default nextConfig;
 - `@prisma/client` (and the generated `.prisma/client`)
 - `jose`
 - `postgres`
+- `react-textarea-autosize`
 
 Please report an issue on [the adapter GH repository](https://github.com/opennextjs/opennextjs-cloudflare/issues) to have packages added to this list.


### PR DESCRIPTION
fixes https://github.com/opennextjs/opennextjs-cloudflare/issues/729

/cc @sommeeeer 