### PR TITLE
Remove incorrect space breaking link

### DIFF
--- a/pages/cloudflare/caching.mdx
+++ b/pages/cloudflare/caching.mdx
@@ -712,7 +712,7 @@ You can only enable cache purge functionality on a zone (e.g., when using a cust
 
 The cache purge component automatically clears the cache when a page is revalidated. It is only necessary if you use On-Demand revalidation along with one of the cache components that leverage the Cache API.
 
-This component can either call the Cache API's purge function directly or route the purge request through an intermediate durable object. Using a durable object helps buffer requests and avoid reaching [API rate limits] (https://developers.cloudflare.com/cache/how-to/purge-cache/#hostname-tag-prefix-url-and-purge-everything-limits).
+This component can either call the Cache API's purge function directly or route the purge request through an intermediate durable object. Using a durable object helps buffer requests and avoid reaching [API rate limits](https://developers.cloudflare.com/cache/how-to/purge-cache/#hostname-tag-prefix-url-and-purge-everything-limits).
 
 Cache purge are only called when you call `revalidateTag`, `revalidatePath` or `res.revalidate` in the pages router. It is not called for ISR revalidation.
 


### PR DESCRIPTION
This is how it currently looks (on https://opennext.js.org/cloudflare/caching#automatic-cache-purge):
<img width="903" height="353" alt="Screenshot 2025-08-14 at 11 19 14" src="https://github.com/user-attachments/assets/e305e813-60e4-4c3f-90db-65c2cb18e8c9" />
