### PR TITLE
docs(cloudflare): Add FinalizationRegistry trouble-shooting

### DIFF
--- a/pages/cloudflare/troubleshooting.mdx
+++ b/pages/cloudflare/troubleshooting.mdx
@@ -125,3 +125,23 @@ X [ERROR] Could not resolve "<package name>"
 It might be because the package contains workerd specific code.
 
 Check this [howto](/cloudflare/howtos/workerd) for a solution.
+
+### `ReferenceError: FinalizationRegistry is not defined`
+
+If you encounter this error when using features that rely on modern JavaScript APIs:
+
+```text
+✘ [ERROR] ⨯ ReferenceError: FinalizationRegistry is not defined
+```
+
+This error occurs because the `FinalizationRegistry` API is not available in older Cloudflare Workers compatibility dates. 
+
+To fix this issue, update your `compatibility_date` in `wrangler.toml` or `wrangler.jsonc` to `2025-05-05` or later:
+
+```json
+{
+  "compatibility_date": "2025-05-05"
+}
+```
+
+Refer to the [Cloudflare Workers compatibility flags documentation](https://developers.cloudflare.com/workers/configuration/compatibility-flags/#enable-finalizationregistry-and-weakref) for more details.


### PR DESCRIPTION
 Summary
---
  Add troubleshooting documentation for ReferenceError: FinalizationRegistry is 
  not defined error

  Context
---
  Related to issue: https://github.com/opennextjs/opennextjs-cloudflare/issues/660
  #issuecomment-2876460231

  I encountered this error during ISR (Incremental Static Regeneration) processes
  and was able to resolve it by updating the compatibility_date in the Wrangler
  configuration. However, finding the solution required significant research
  effort.

  Changes

  - Added a new troubleshooting section for the FinalizationRegistry error
  - Included the fix: updating compatibility_date to 2025-05-05 or later
  - Added reference to official Cloudflare documentation

  Motivation

  This documentation will help other developers quickly find and resolve this
  issue, reducing the time spen