### PR TITLE
docs(cloudflare): document populateCache setup behind Cloudflare Access

### DIFF
--- a/pages/cloudflare/cli.mdx
+++ b/pages/cloudflare/cli.mdx
@@ -36,6 +36,43 @@ The `populateCache` command supports R2 batching to speed up the upload of large
 
 </Callout>
 
+#### Populating remote bindings when Workers are protected by Cloudflare Access
+
+`populateCache remote` (also called implicitly by `deploy` and `upload`) temporarily deploys a helper Worker named `open-next-cache-populate` at `open-next-cache-populate.<account>.workers.dev` and uses it to write to your remote R2 bucket.
+
+If your account's `workers.dev` subdomain — or a parent route on a custom domain — is protected by [Cloudflare Access](https://developers.cloudflare.com/cloudflare-one/applications/), the helper Worker is protected by the same policy and the upload fails with either:
+
+```text
+Failed to send request to R2 worker: The operation was aborted due to timeout.
+```
+
+or a `403 Forbidden` returned by the Access edge.
+
+To let the adapter authenticate:
+
+1. Open the **existing** Cloudflare Access application that already covers `open-next-cache-populate.<account>.workers.dev` — typically the wildcard application for `*.<account>.workers.dev` — and attach the policy described below to that application.
+
+   <Callout type="warning">
+     Creating a separate Access application scoped specifically to the `open-next-cache-populate` hostname has
+     been observed to block the upload, even when kept alongside the existing wildcard application (see
+     [#1171](https://github.com/opennextjs/opennextjs-cloudflare/issues/1171)). Prefer attaching the policy to
+     the existing application that already protects the hostname.
+   </Callout>
+
+2. Add a **Service Auth** policy to that application:
+
+   - Set the policy **Action** to "Service Auth".
+   - Add an **Include** rule for "Any Access Service Token", or for a specific service token.
+
+3. Create the service token under Zero Trust → Access → Service Auth → Service Tokens, then expose its credentials to the environment that runs `opennextjs-cloudflare`:
+
+   ```sh
+   export CLOUDFLARE_ACCESS_CLIENT_ID=<id>
+   export CLOUDFLARE_ACCESS_CLIENT_SECRET=<secret>
+   ```
+
+   Then run `opennextjs-cloudflare populateCache remote` (or `deploy` / `upload`). In CI, set the two values as secrets and expose them to the deploy step.
+
 ### `preview` command
 
 It starts by populating the local cache and then launches a local development server (via `wrangler dev`) so that you can preview the application locally.

--- a/pages/cloudflare/troubleshooting.mdx
+++ b/pages/cloudflare/troubleshooting.mdx
@@ -135,3 +135,9 @@ To fix this issue, update your `compatibility_date` in `wrangler.toml` or `wrang
 ```
 
 Refer to the [Cloudflare Workers compatibility flags documentation](https://developers.cloudflare.com/workers/configuration/compatibility-flags/#enable-finalizationregistry-and-weakref) for more details.
+
+### `Failed to send request to R2 worker` or `Could not determine Cloudflare auth credentials after login`
+
+These errors come from `populateCache remote` (called implicitly by `deploy` and `upload`) when the temporary `open-next-cache-populate.<account>.workers.dev` helper Worker is fronted by a Cloudflare Access application.
+
+See [Populating remote bindings when Workers are protected by Cloudflare Access](/cloudflare/cli#populating-remote-bindings-when-workers-are-protected-by-cloudflare-access) for setup steps.


### PR DESCRIPTION
## Summary

- Adds a new sub-section to `pages/cloudflare/cli.mdx` under the `populateCache` command, explaining what to do when the temporary `open-next-cache-populate.<account>.workers.dev` helper Worker is fronted by a Cloudflare Access application (the scenario introduced by opennextjs/opennextjs-cloudflare#1261).
- Adds a cross-linked troubleshooting entry in `pages/cloudflare/troubleshooting.mdx` for the two error messages users typically hit in this scenario (`Failed to send request to R2 worker` and `Could not determine Cloudflare auth credentials after login`).

## Why

The only existing guidance for this setup is the `@opennextjs/cloudflare` v1.19.10 changelog entry, which reads:

> create a "Service Auth" policy for "open-next-cache-populate.<account>.workers.dev"

That phrasing is ambiguous about whether to create a **new** Access application for the hostname or attach the policy to an **existing** application that already covers it. The discussion in opennextjs/opennextjs-cloudflare#1171 (comment [#4460317679](https://github.com/opennextjs/opennextjs-cloudflare/issues/1171#issuecomment-4460317679)) shows multiple users falling into the same trap. The user that eventually got it working reported:

> if you already have an Access application whose URL covers `open-next-cache-populate.<account>.workers.dev` (e.g. a `*.<account>.workers.dev` wildcard), just attach the service auth policy from #1261 to that existing application. DO NOT create a new application for `open-next-cache-populate.<account>.workers.dev`.

The new sub-section captures that — phrased as observed behaviour rather than a hard rule, since we don't yet know the root cause of why the separate-application setup blocks the upload.

## Notes

- Prettier passes (`npx prettier@3.5.2 --check pages/cloudflare/cli.mdx pages/cloudflare/troubleshooting.mdx`).
- The new heading is level-4 (`####`) so it nests under the existing `### populateCache command` section in the page TOC.
- The companion in-code comment in `populate-cache.ts` is being updated in a separate PR on opennextjs/opennextjs-cloudflare so future maintainers don't re-introduce the ambiguous wording in changelogs.